### PR TITLE
Perf counters work in .NET versions other than 4.5

### DIFF
--- a/Nabbix.Tests/WindowsPerformanceCountersTests.cs
+++ b/Nabbix.Tests/WindowsPerformanceCountersTests.cs
@@ -1,4 +1,4 @@
-﻿#if NET45
+﻿using System.Diagnostics;
 using Xunit;
 
 namespace Nabbix.Tests
@@ -8,13 +8,13 @@ namespace Nabbix.Tests
         [Fact]
         public void MethodName_StateUnderTest_ExpectedBehavior()
         {
-            var counterA = WindowsPerformanceCounters.ParseCounter(@"perf_counter[""\Processor Information(_Total)\% Processor Time""]");
-            var counterB = WindowsPerformanceCounters.ParseCounter(@"perf_counter[""\Memory\Available Bytes""]");
+            PerformanceCounter counterA = WindowsPerformanceCounters.ParseCounter(
+                @"perf_counter[""\Processor Information(_Total)\% Processor Time""]");
+            PerformanceCounter counterB = WindowsPerformanceCounters.ParseCounter(
+                @"perf_counter[""\Memory\Available Bytes""]");
 
-            Assert.IsNotNull(counterA);
-            Assert.IsNotNull(counterB);
+            Assert.True(counterA != null);
+            Assert.True(counterB != null);
         }
-
     }
 }
-#endif

--- a/Nabbix/Nabbix.csproj
+++ b/Nabbix/Nabbix.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <Version>$(PackageVersion)</Version>
     <AssemblyVersion>$(PackageVersion)</AssemblyVersion>
     <PackageLicenseUrl>https://github.com/nolstoy/nabbix/blob/master/LICENSE.txt</PackageLicenseUrl>
@@ -13,8 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Fasterflect.Netstandard" Version="1.0.8" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
   </ItemGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45'">
-    <DefineConstants>NET45</DefineConstants>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Quick fix for the issue. 
The basic fix is a new way of detecting whether the current OS is Windows.
I also updated from NET 4.5 to .NET 4.6.1 in order to get generalized perf counters that work in  netstandard2.0.